### PR TITLE
Slimming down the image so that the image is below 2.0GB threshold

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,25 +6,10 @@ ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
 ##############################################################################
-## Ensure DNS is working properly: 
-## https://gist.github.com/ThePlenkov/6ecf2a43e2b3898e8cd4986d277b5ecf
-##
-## Make the resolv.conf file immutable so that wsl won't delete it on startup
-## https://github.com/microsoft/wsl/issues/5420
-##############################################################################
-COPY config/wsl.conf /etc/wsl.conf
-RUN echo "nameserver 8.8.8.8" > /etc/resolv.conf
-
-## Can't seem to make resolv.conf immutable. Writing a script fix-dns.sh instead.
-## RUN chattr -f +i /etc/resolv.conf
-
-RUN apt-get update -q
-
-##############################################################################
 # Install Linux based tools for various activities such as networking,
 # certificate management, software engineering, and building other software.
 ##############################################################################
-RUN apt-get update && apt-get install -y \
+RUN apt-get update -q && apt-get install -y \
   autossh \
   ca-certificates \
   dnsutils \
@@ -73,68 +58,27 @@ RUN git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.13.1 && \
   echo ". $HOME/.asdf/asdf.sh" >> /root/.bashrc && \
   echo ". $HOME/.asdf/asdf.sh" >> /root/.zshrc
 
+COPY config/.tool-versions ".tool-versions"
+
 # Add asdf to profile, so it is available in `podman run`
 ENV PATH="$PATH:/root/.asdf/bin"
 
 # Add asdf shims to PATH, so installed executables can be run in this Dockerfile
 ENV PATH="$PATH:/root/.asdf/shims"
 
+##############################################################################
+## Python itself can take up 1GB. All other tools are in the folder:
+## opt/scripts/add-extra-tools.sh
+##
+## There is a side limit to releases of 2GB by Github.
+##############################################################################
 RUN asdf plugin add awscli && \
-    # asdf plugin add azure-cli && \
-    asdf plugin add gradle && \
-    asdf plugin add helm && \
-    asdf plugin add java && \
-    asdf plugin add kubectl && \
-    asdf plugin add maven && \
-    asdf plugin add nodejs && \
+    asdf plugin add azure-cli && \
     asdf plugin add oc && \
-    asdf plugin add pre-commit && \
-    asdf plugin add podman https://github.com/tvon/asdf-podman.git && \
     asdf plugin add python && \
-    asdf plugin add sbt && \
-    asdf plugin add scala && \
-    asdf plugin add steampipe && \
+    asdf plugin add podman https://github.com/tvon/asdf-podman.git && \
     asdf plugin add terraform && \
-    asdf plugin add trivy
-
-# # COPY config/.tool-versions "$PATH:/root/.asdf/.tool-versions"
-# # RUN asdf install
-
-RUN asdf install awscli 2.13.26 && \
-    # asdf install azure-cli 2.53.0 && \
-    asdf install gradle 8.2.1 && \
-    asdf install helm 3.12.3 && \
-    asdf install java temurin-11.0.20+8 && \
-    asdf install kubectl 1.28.2 && \
-    asdf install maven 3.9.5 && \
-    asdf install nodejs 18.18.1 && \
-    asdf install oc 4.13.16 && \
-    asdf install podman 4.7.1 && \
-    asdf install pre-commit 3.3.3 && \
-    asdf install python 3.11.6 && \
-    asdf install sbt 1.7.1 && \
-    asdf install scala 3.1.3 && \
-    asdf install steampipe 0.20.12 && \
-    asdf install terraform 1.5.3 && \
-    asdf install trivy 0.45.0
-
-RUN asdf global awscli 2.13.26 && \
-    # asdf global azure-cli 2.53.0 && \
-    asdf global gradle 8.2.1 && \
-    asdf global helm 3.12.3 && \
-    asdf global java temurin-11.0.20+8 && \
-    asdf global kubectl 1.28.2 && \
-    asdf global maven 3.9.5 && \
-    asdf global nodejs 18.18.1 && \
-    asdf global oc 4.13.16 && \
-    asdf global podman 4.7.1 && \
-    asdf global pre-commit 3.3.3 && \
-    asdf global python 3.11.6 && \
-    asdf global sbt 1.7.1 && \
-    asdf global scala 3.1.3 && \
-    asdf global steampipe 0.20.12 && \
-    asdf global terraform 1.5.3 && \
-    asdf global trivy 0.45.0
+    asdf install
 
 ###########################################################################
 ## Update bashrc with auto branch complete so that the branch shows up in  
@@ -146,12 +90,19 @@ RUN echo 'parse_git_branch() {' >> /root/.bashrc && \
   echo '}' >> /root/.bashrc && \
   echo 'export PS1="\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$(parse_git_branch)\$ "' >> /root/.bashrc
 
+##############################################################################
+## Ensure DNS is working properly: 
+## https://gist.github.com/ThePlenkov/6ecf2a43e2b3898e8cd4986d277b5ecf
+##
+## Make the resolv.conf file immutable so that wsl won't delete it on startup
+## https://github.com/microsoft/wsl/issues/5420
+##############################################################################
+COPY config/wsl.conf /etc/wsl.conf
+
 ###########################################################################
 ## Copy helpful bash scripts over for testing the environment.
 ###########################################################################
-COPY scripts/add-user.sh opt/scripts/add-user.sh
-COPY scripts/check-google.sh opt/scripts/check-google.sh
-COPY scripts/fix-time.sh opt/scripts/fix-time.sh
+COPY scripts/ opt/scripts/
 
 # Clean up the local repository of retrieved package files, useful only for
 # local environments which don't have any cleanup mechanism.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,22 @@ to run
 
 `wsl -d ubuntu-22.04`
 
+## Installing Extra Tools
+
+Inside the image, the /opt/scripts folder has a script to install [an additional list](./scripts/add-extra-tools.sh) of tools.
+
+To install this list of tools, run `bash /opt/scripts/add-extra-tools.sh`. We couldn't fit it all into the image due to a [2GB restriction](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases#storage-and-bandwidth-quotas).
+
+## Change Tool versions
+
+We utilize [asdf](https://asdf-vm.com/) to install common programming tools and it comes with a [tool versions file](./config/.tool-versions).
+
+To update or change the version of [these tools](./config/.tool-versions), change the version of the tool in the file; ex. python 3.11.6, save the file, and run `asdf install`.
+
+Once it is completed, you can run `python -v` with python 3.11.6.
+
+Use `asdf list-all python` to figure out the available versions of python you can install.
+
 ## WSL Tricks
 
 To find out what distros are running, run `wsl --list --running`.
@@ -53,6 +69,9 @@ For whatever reason, occasionally if you run `wsl --shutdown`, you may end up cr
 - update-ca-certificates don't seem to update any certificates
   - Fixed - had to change the format of the file from .pem to a .crt for update-ca-certificates to pick it up.
 - azure-cli with asdf can't install and won't run.
+  - Fixed - needed to install Python and use a ~/.tool-versions file to install.
+- Github Releases per file has a [upper limit of 2GB](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases#storage-and-bandwidth-quotas).
+  - Sort of fixed - slim down the image.
 
 ## Links to Follow
 

--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,7 @@ fi
 TAR_DIR="$PWD/images"
 mkdir -p "$TAR_DIR"
 IMAGE_NAME="ubuntu-22.04-cdc"
-IMAGE_VERSION="1.1"
+IMAGE_VERSION="1.2"
 
 # Build, run, and save the image as a docker image in a tar file
 # so it can be used later

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -3,7 +3,7 @@
 set -eu
 
 IMAGE_NAME="ubuntu-22.04-cdc"
-IMAGE_VERSION="1.0"
+IMAGE_VERSION="1.2"
 
 # Use awk to extract container IDs into an array
 containerIDs=($(podman container ls -a | grep -i "$IMAGE_NAME:$IMAGE_VERSION" | awk '{print $1}'))

--- a/config/.tool-versions
+++ b/config/.tool-versions
@@ -2,13 +2,13 @@ awscli 2.13.26
 azure-cli 2.53.0
 gradle 8.2.1
 helm 3.12.3
-java temurin-11.0.20+8
+java temurin-jre-18.0.2+101
 kubectl 1.28.2
 maven 3.9.5
 nodejs 18.18.1
 oc 4.13.16
 pre-commit 3.3.3
-python 3.11.6
+python 3.10.11
 sbt 1.7.1
 scala 3.1.3
 steampipe 0.20.12

--- a/scripts/add-extra-tools.sh
+++ b/scripts/add-extra-tools.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -eu
+
+asdf plugin add java
+asdf plugin add nodejs
+asdf plugin add helm
+asdf plugin add gradle
+asdf plugin add kubectl
+asdf plugin add maven
+asdf plugin add pre-commit
+asdf plugin add sbt
+asdf plugin add scala
+asdf plugin add steampipe
+asdf plugin add trivy
+asdf plugin add yarn
+
+asdf install


### PR DESCRIPTION
## Updates

- Slimming down the image to a little less than 2GB.
- Tried to optimize the layers.
- Moved the extra tools to another file, and updated README on how to run this.

## Testing Steps
- Local run: `bash build.sh` until the image is slim enough.
The size 2108866560 is smaller than 2147483648, so we should be good to go.

> stat images/ubuntu-22.04-cdc\:1.2-202310181234.tar

>   File: images/ubuntu-22.04-cdc:1.2-202310181234.tar
  Size: **2108866560**      Blocks: 4118888    IO Block: 4096   regular file
Device: 10302h/66306d   Inode: 81690093    Links: 1
Access: (0664/-rw-rw-r--)  Uid: ( 1000/momotaro)   Gid: ( 1000/momotaro)
Access: 2023-10-17 20:34:35.689649596 -0400
Modify: 2023-10-17 20:34:48.978011816 -0400
Change: 2023-10-17 20:34:48.978011816 -0400
 Birth: 2023-10-17 20:34:35.689649596 -0400
