### PR TITLE
fix: distro for semantic release

### DIFF
--- a/.github/workflows/distro.yml
+++ b/.github/workflows/distro.yml
@@ -21,10 +21,8 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write # to be able to publish a GitHub release
-      issues: write # to be able to comment on released issues
-      pull-requests: write # to be able to comment on released pull requests
+    environment:
+      name: github-app-cdc-coe-botfrey
     steps:
       - name: Checkout the codebase
         uses: actions/checkout@v4
@@ -59,9 +57,27 @@ jobs:
         run: |
           bash build.sh
 
+      ## The default Github token does not provide a way for semantic release
+      ## to publish to a protected branch without having an administrative bot
+      ## account with bypass options within the repository's settings.
+      ## https://github.com/orgs/community/discussions/25305
+      - name: Get Github App token
+        if: github.ref == 'refs/heads/main'
+        id: generate_token
+        run: |
+          echo "${{ secrets.PRIVATE_KEY }}" > private.pem
+
+          result=$(npx github-app-installation-token \
+            --appId ${{ vars.APP_ID }} \
+            --installationId ${{ vars.INSTALLATION_ID }} \
+            --privateKeyLocation private.pem)
+
+          echo "TOKEN=$result" >> "$GITHUB_OUTPUT"
+
       - name: Release
         if: github.ref == 'refs/heads/main'
         env:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          GH_TOKEN: '${{ steps.generate_token.outputs.TOKEN }}'
+          GITHUB_TOKEN: '${{ steps.generate_token.outputs.TOKEN }}'
         run: |
           npx semantic-release


### PR DESCRIPTION
## Updates

- fix: Adding in all the environment variables settings for semantic release to deploy a new version. Copying from [cdc-coe-tf-modules](https://github.com/cdcent/cdc-coe-tf-modules/blob/main/.github/workflows/tagging.yml#L35) settings and environment variables.

## Testing Steps

- We'll do it live.