### PR TITLE
fix: bash color scheme problem and fix time script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ RUN asdf plugin add python && asdf install && asdf global python 3.11.6
 ## accidental check-ins or deletions.
 ###########################################################################
 RUN printf 'parse_git_branch() {\n  git branch 2> /dev/null | sed -e "/^[^*]/d" -e "s/* \\(.*\\)/(\\1)/"\n}\n' >> /root/.bashrc && \
-  printf "PS1='\${debian_chroot:+(\$debian_chroot)}\[\\\\033[01;32m\\\\]\u@\\h\\[\\\\033[00m\\\\]:\\[\\\\033[01;34m\\\\]\w\[\\\\033[01;31m\\\\]\$(parse_git_branch)\[\\\\033[00m\\\\]\\$ '\n" >> /root/.bashrc
+  printf "PS1='\${debian_chroot:+(\$debian_chroot)}\[\\\\033[01;32m\\\\]\u@\\h\\[\\\\033[00m\\\\]:\\[\\\\033[01;35m\\\\]\w\[\\\\033[01;31m\\\\]\$(parse_git_branch)\[\\\\033[00m\\\\]\\$ '\n" >> /root/.bashrc
 
 ###########################################################################
 ## Podman requires knowing which container registries to pull from

--- a/scripts/fix-time.sh
+++ b/scripts/fix-time.sh
@@ -32,7 +32,7 @@ set_timezone() {
   esac
 
   # Set the timezone
-  sudo timedatectl set-timezone $timezone
+  timedatectl set-timezone $timezone
 
   echo "Timezone set to $timezone"
 }
@@ -47,7 +47,7 @@ fi
 ## Usage of this script: sudo ./set_timezone.sh Eastern
 ##########################################################
 if [ $# -eq 0 ]; then
-  echo "Usage: sudo $0 [Eastern|Central|Mountain|Pacific|UTC]"
+  echo "Usage: $0 [Eastern|Central|Mountain|Pacific|UTC]"
   exit 1
 fi
 


### PR DESCRIPTION
## Updates

- Removing `sudo` from fix-time.sh script, the script is usually already running as root when accessing `wsl`, so the sudo isn't needed and will cause the script to fail.
- Changing the Linux terminal directory color to **magneta**, instead of **dark blue**. The background of the terminal is black and it's really hard on the eyes to have dark blue text on black background. The internet had this handy list.
![image](https://github.com/cdcent/ocio-wsl/assets/41026275/211a908f-228b-4e51-af2d-5584f7004d5d)


```
# 30 black
# 31 red
# 32 green
# 33 yellow
# 34 blue
# 35 magenta
# 36 cyan
# 37 white
```

## Testing Steps

- Tested inside `wsl`, made the changes there as shown above.