### PR TITLE
fix to handle relative paths

### DIFF
--- a/.github/workflows/trivy-scan-docker-files.yaml
+++ b/.github/workflows/trivy-scan-docker-files.yaml
@@ -70,7 +70,12 @@ jobs:
           mkdir -p "$base_dir/reports/comments"
 
           for dir in $changed_dirs; do
-            safe_name=${dir//\//-}
+            rel_dir=$(realpath --relative-to="." "$dir")
+            if [[ "$rel_dir" == "." ]] then
+              safe_name="latest"
+            else
+              safe_name="latest-${rel_dir//\//-}"
+            fi
             echo "Processing $dir (safe name: $safe_name)"
             docker build -t tst-app:${safe_name} "$dir"
 


### PR DESCRIPTION
## Additions

-

## Removals

-

## Updates

- Updated trivy workflow logic to handle error due to relative dir name being used in docker build command tag:
![image](https://github.com/user-attachments/assets/0efc7169-d491-468d-b443-a5a25c7d28a3)


## Testing Steps

Wrote bash script to test changes. For '.' tag becomes 'tst-app:latest'.  For './subdir' tag becomes 'tst-app:latest-subdir', which follows the original intent.

## Notes

-
