### PR TITLE
EDSO-3291 only github-hosted runners allowed for public repos

### DIFF
--- a/.github/workflows/trivy-scan-docker-files.yaml
+++ b/.github/workflows/trivy-scan-docker-files.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   trivy-scan:
-    runs-on: [edso-non-prod-runner]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code 
         uses: actions/checkout@v4


### PR DESCRIPTION
## Additions

-

## Removals

-

## Updates

- Updated runner for trivy scan since only github-hosted runners are allowed for public repos.

## Testing Steps

-

## Notes

-
