### PR TITLE
fix: use the github token to merge

### DIFF
--- a/.github/workflows/update-cert.yml
+++ b/.github/workflows/update-cert.yml
@@ -58,6 +58,7 @@ jobs:
         run: |
           git config --global user.email "noreply@github.com"
           git config --global user.name "github-automation"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git status
 
       - name: Switch to branch


### PR DESCRIPTION
## Updates

- fix: use the github token to do the merging of the certificates.

## Testing Steps

-

## Notes

-
