### PR TITLE
fix: deployment doing too much and badges to display in README

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,16 @@
-name: Redeploy Manually
+name: Build and Release WSL Images
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+      - 'images/**'
+      - '**.md'
+      - '!README.md'
+      - '.github/workflows/stats.yml'
 
 jobs:
   deploy:
@@ -13,8 +22,8 @@ jobs:
     environment:
       name: ocio-edso-gh-actions-app
     steps:
-      ## App token must be created before checkout so the checkout uses it,
-      ## allowing semantic-release to push to the protected main branch.
+      ## App token must be created before checkout so semantic-release can
+      ## push the version commit back to the protected main branch.
       ## https://github.com/orgs/community/discussions/25305
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
@@ -62,29 +71,26 @@ jobs:
           sha256sum ubuntu-24.04-cdc.wsl fedora-43-cdc.wsl > checksums.txt
         working-directory: ./images
 
-      - name: Release
-        id: release
+      # Dry-run to get the next version so we can generate the manifest before
+      # the release is published. This avoids the HTTP 422 immutable-release
+      # error that occurs when uploading assets after publication.
+      - name: Compute next release version
+        id: next-version
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          npx semantic-release
-          NEXT_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          if [ -n "$NEXT_TAG" ] && [ "$PREV_TAG" != "$NEXT_TAG" ]; then
-            echo "released=true" >> "$GITHUB_OUTPUT"
-            echo "version=$NEXT_TAG" >> "$GITHUB_OUTPUT"
-          else
-            echo "released=false" >> "$GITHUB_OUTPUT"
-          fi
+          NEXT_VERSION=$(npx semantic-release --dry-run 2>&1 \
+            | grep -oP '(?<=The next release version is )\S+' || echo "")
+          echo "version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "will_release=$([ -n "$NEXT_VERSION" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
-      - name: Generate and publish manifest
-        if: steps.release.outputs.released == 'true'
+      - name: Generate manifest
+        if: steps.next-version.outputs.will_release == 'true'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          NEXT_VERSION: ${{ steps.next-version.outputs.version }}
         run: |
-          VERSION="${{ steps.release.outputs.version }}"
+          VERSION="$NEXT_VERSION"
           BASE_URL="https://github.com/${{ github.repository }}/releases/download/$VERSION"
 
           UBUNTU_SHA=$(sha256sum images/ubuntu-24.04-cdc.wsl | cut -d' ' -f1)
@@ -121,4 +127,8 @@ jobs:
           }
           EOF
 
-          gh release upload "$VERSION" images/manifest.json --clobber
+      - name: Release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: npx semantic-release

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,16 +1,6 @@
-name: Release WSL Image
+name: PR Version Check
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - 'docs/**'
-      - 'images/**'
-      - '**.md'
-      - '!README.md'
-      - '.github/workflows/stats.yml'
   pull_request:
     branches:
       - '**'
@@ -19,23 +9,18 @@ on:
       - 'images/**'
       - '**.md'
       - '!README.md'
-      - '.github/workflows/stats.yml'
       - 'config/bundle-ca.pem'
 
 jobs:
-  deploy:
+  version-check:
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       issues: write
     runs-on: ubuntu-latest
     environment:
       name: ocio-edso-gh-actions-app
     steps:
-      ## The default Github token does not provide a way for semantic release
-      ## to publish to a protected branch without having an administrative bot
-      ## account with bypass options within the repository's settings.
-      ## https://github.com/orgs/community/discussions/25305
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
@@ -67,9 +52,9 @@ jobs:
       # https://github.com/semantic-release/semantic-release/issues/1890#issuecomment-974512960
       - name: 🔬 Check semantic versioning
         id: semantic-release
-        if: ${{ github.ref != 'refs/heads/main' }}
         env:
           base_ref: ${{ github.base_ref }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git checkout -b "$base_ref" pull/${{ github.event.number }}/merge
           unset GITHUB_ACTIONS;
@@ -79,13 +64,12 @@ jobs:
 
       - name: 📝 Report semantic versioning
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        if: github.ref != 'refs/heads/main' && steps.semantic-release.outputs.releaseNote != ''
+        if: steps.semantic-release.outputs.releaseNote != ''
         env:
           RELEASE_NOTE: '${{ steps.semantic-release.outputs.releaseNote }}'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            // build release note
             const semanticReleaseOutput = Buffer.from(process.env.RELEASE_NOTE, 'base64').toString('utf8');
             const semanticReleaseLogMatch = /^[[0-9:\sAMPM]+\]\s\[semantic-release\].*$/;
             const lines = semanticReleaseOutput.split('\n');
@@ -104,19 +88,16 @@ jobs:
             const SEMANTIC_RELEASE_BODY_HEADER = '## 📝 Semantic Release Report';
             const body = [SEMANTIC_RELEASE_BODY_HEADER, res].join('\n');
 
-            // get last comment
             const comments = await github.rest.issues.listComments({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo
             });
 
-            // find comments to delete
             const commentsToDelete = comments.data.filter((comment) =>
               comment.body.startsWith(SEMANTIC_RELEASE_BODY_HEADER)
             );
 
-            // delete comments
             const prms = commentsToDelete.map((comment) =>
               github.rest.issues.deleteComment({
                 comment_id: comment.id,
@@ -127,91 +108,9 @@ jobs:
 
             await Promise.all(prms);
 
-            // create new comment for release note
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
               body
             });
-
-      - name: Set up Podman
-        run: |
-          if ! command -v podman &> /dev/null; then
-            sudo apt update
-            sudo apt install -y podman
-          fi
-          podman --version
-        shell: bash
-
-      - name: Generate WSL images
-        run: |
-          bash build.sh ubuntu
-          bash build.sh fedora
-
-      - name: Generate checksums
-        run: |
-          sha256sum ubuntu-24.04-cdc.wsl fedora-43-cdc.wsl > checksums.txt
-        working-directory: ./images
-
-      - name: Release
-        id: release
-        if: github.ref == 'refs/heads/main'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          npx semantic-release
-          NEXT_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          if [ -n "$NEXT_TAG" ] && [ "$PREV_TAG" != "$NEXT_TAG" ]; then
-            echo "released=true" >> "$GITHUB_OUTPUT"
-            echo "version=$NEXT_TAG" >> "$GITHUB_OUTPUT"
-          else
-            echo "released=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Generate and publish manifest
-        if: github.ref == 'refs/heads/main' && steps.release.outputs.released == 'true'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          VERSION="${{ steps.release.outputs.version }}"
-          BASE_URL="https://github.com/${{ github.repository }}/releases/download/$VERSION"
-
-          UBUNTU_SHA=$(sha256sum images/ubuntu-24.04-cdc.wsl | cut -d' ' -f1)
-          FEDORA_SHA=$(sha256sum images/fedora-43-cdc.wsl | cut -d' ' -f1)
-          UBUNTU_SHA_FMT="0x$(echo "$UBUNTU_SHA" | tr '[:lower:]' '[:upper:]')"
-          FEDORA_SHA_FMT="0x$(echo "$FEDORA_SHA" | tr '[:lower:]' '[:upper:]')"
-
-          cat > images/manifest.json << EOF
-          {
-            "ModernDistributions": {
-              "cdc-ubuntu": [
-                {
-                  "Name": "cdc-ubuntu",
-                  "FriendlyName": "CDC Ubuntu 24.04",
-                  "Default": true,
-                  "Amd64Url": {
-                    "Url": "$BASE_URL/ubuntu-24.04-cdc.wsl",
-                    "Sha256": "$UBUNTU_SHA_FMT"
-                  }
-                }
-              ],
-              "cdc-fedora": [
-                {
-                  "Name": "cdc-fedora",
-                  "FriendlyName": "CDC Fedora 43",
-                  "Default": true,
-                  "Amd64Url": {
-                    "Url": "$BASE_URL/fedora-43-cdc.wsl",
-                    "Sha256": "$FEDORA_SHA_FMT"
-                  }
-                }
-              ]
-            }
-          }
-          EOF
-
-          gh release upload "$VERSION" images/manifest.json --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,239 +1,207 @@
 # [2.6.0](https://github.com/cdcgov/ocio-wsl/compare/2.5.7...2.6.0) (2026-05-07)
 
-
 ### Features
 
-* release with fedora 43 and ubuntu 24.04 ([b0e5e67](https://github.com/cdcgov/ocio-wsl/commit/b0e5e67ed14f89058fbc03d9f0e8fd40f4ca6630))
+- release with fedora 43 and ubuntu 24.04 ([b0e5e67](https://github.com/cdcgov/ocio-wsl/commit/b0e5e67ed14f89058fbc03d9f0e8fd40f4ca6630))
 
 ## [2.5.7](https://github.com/cdcgov/ocio-wsl/compare/2.5.6...2.5.7) (2026-04-18)
 
-
 ### Bug Fixes
 
-* fix broken pipeline for merging, rebase only for this repository ([6a4a45c](https://github.com/cdcgov/ocio-wsl/commit/6a4a45ce147421b29b705232eefaf30e488eccc3))
+- fix broken pipeline for merging, rebase only for this repository ([6a4a45c](https://github.com/cdcgov/ocio-wsl/commit/6a4a45ce147421b29b705232eefaf30e488eccc3))
 
 ## [2.5.6](https://github.com/cdcgov/ocio-wsl/compare/2.5.5...2.5.6) (2026-04-18)
 
-
 ### Bug Fixes
 
-* use the github token to merge ([7c132a2](https://github.com/cdcgov/ocio-wsl/commit/7c132a2584c35f0eda0fd5097ded576788a9742f))
+- use the github token to merge ([7c132a2](https://github.com/cdcgov/ocio-wsl/commit/7c132a2584c35f0eda0fd5097ded576788a9742f))
 
 ## [2.5.5](https://github.com/cdcgov/ocio-wsl/compare/2.5.4...2.5.5) (2026-04-14)
 
-
 ### Bug Fixes
 
-* build badge ([75947b3](https://github.com/cdcgov/ocio-wsl/commit/75947b3362d3a28023dff617928e543258a293b7))
+- build badge ([75947b3](https://github.com/cdcgov/ocio-wsl/commit/75947b3362d3a28023dff617928e543258a293b7))
 
 ## [2.5.4](https://github.com/cdcgov/ocio-wsl/compare/2.5.3...2.5.4) (2026-04-14)
 
-
 ### Bug Fixes
 
-* locking down mise versions and update all dependencies ([0fb7684](https://github.com/cdcgov/ocio-wsl/commit/0fb768486142f47293e84e6747d2f27214f7b400))
-* npm deps group together from dependabot ([761a3b1](https://github.com/cdcgov/ocio-wsl/commit/761a3b1eacbfbddf224f9149d35c8c2e83067f56))
-* stop trivy from complaining ([0ba2d8f](https://github.com/cdcgov/ocio-wsl/commit/0ba2d8fd66c184fc2267b9db1c73328156345db3))
-* update depreciated setup ([6b59de2](https://github.com/cdcgov/ocio-wsl/commit/6b59de233e9d395d4f6a9c958d3e06c2ea7db0ca))
+- locking down mise versions and update all dependencies ([0fb7684](https://github.com/cdcgov/ocio-wsl/commit/0fb768486142f47293e84e6747d2f27214f7b400))
+- npm deps group together from dependabot ([761a3b1](https://github.com/cdcgov/ocio-wsl/commit/761a3b1eacbfbddf224f9149d35c8c2e83067f56))
+- stop trivy from complaining ([0ba2d8f](https://github.com/cdcgov/ocio-wsl/commit/0ba2d8fd66c184fc2267b9db1c73328156345db3))
+- update depreciated setup ([6b59de2](https://github.com/cdcgov/ocio-wsl/commit/6b59de233e9d395d4f6a9c958d3e06c2ea7db0ca))
 
 ## [2.5.3](https://github.com/cdcgov/ocio-wsl/compare/2.5.2...2.5.3) (2026-04-14)
 
-
 ### Bug Fixes
 
-* updating the certificate flow ([ccb8f26](https://github.com/cdcgov/ocio-wsl/commit/ccb8f26b77bdcbe875c79ebdd08d2958eb0cf078))
+- updating the certificate flow ([ccb8f26](https://github.com/cdcgov/ocio-wsl/commit/ccb8f26b77bdcbe875c79ebdd08d2958eb0cf078))
 
 ## [2.5.2](https://github.com/cdcgov/ocio-wsl/compare/2.5.1...2.5.2) (2025-11-25)
 
-
 ### Bug Fixes
 
-* make utility bash scripts executable ([#90](https://github.com/cdcgov/ocio-wsl/issues/90)) ([4a5d6a1](https://github.com/cdcgov/ocio-wsl/commit/4a5d6a1ae18d6b6fb681e7fe6514c253b99b4b73))
+- make utility bash scripts executable ([#90](https://github.com/cdcgov/ocio-wsl/issues/90)) ([4a5d6a1](https://github.com/cdcgov/ocio-wsl/commit/4a5d6a1ae18d6b6fb681e7fe6514c253b99b4b73))
 
 ## [2.5.1](https://github.com/cdcgov/ocio-wsl/compare/2.5.0...2.5.1) (2025-11-25)
 
+### Bug Fixes
+
+- locking npm due to broken deps ([#98](https://github.com/cdcgov/ocio-wsl/issues/98)) ([ae91163](https://github.com/cdcgov/ocio-wsl/commit/ae911633f49b66ac2f13f282eab61305fdc20fa5))
+- removing stats from running and failing ([#96](https://github.com/cdcgov/ocio-wsl/issues/96)) ([c8f689a](https://github.com/cdcgov/ocio-wsl/commit/c8f689a098905b0c432ee62bd313fed9ab2e7c5f))
+
+# [2.5.0](https://github.com/cdcgov/ocio-wsl/compare/2.4.0...2.5.0) (2025-07-07)
+
+### Features
+
+- upgrading os packages and mise tools ([#83](https://github.com/cdcgov/ocio-wsl/issues/83)) ([45a4033](https://github.com/cdcgov/ocio-wsl/commit/45a40339c812b730c482f41e7e9acece542a5cb1))
+
+# [2.4.0](https://github.com/cdcgov/ocio-wsl/compare/2.3.0...2.4.0) (2025-04-09)
+
+### Features
+
+- Edso 2238 configure dns ([#81](https://github.com/cdcgov/ocio-wsl/issues/81)) ([615b77d](https://github.com/cdcgov/ocio-wsl/commit/615b77d89f76c620e6a982e725e84025c1f40042))
+
+# [2.3.0](https://github.com/cdcgov/ocio-wsl/compare/2.2.1...2.3.0) (2025-04-03)
+
+### Features
+
+- EDSO-1089 add default user on startup ([#80](https://github.com/cdcgov/ocio-wsl/issues/80)) ([063fb69](https://github.com/cdcgov/ocio-wsl/commit/063fb697d2dee8d4fff3d5a62ff4ce44c0ff7067))
+
+## [2.2.1](https://github.com/cdcgov/ocio-wsl/compare/2.2.0...2.2.1) (2025-04-01)
 
 ### Bug Fixes
 
-* locking npm due to broken deps ([#98](https://github.com/cdcgov/ocio-wsl/issues/98)) ([ae91163](https://github.com/cdcgov/ocio-wsl/commit/ae911633f49b66ac2f13f282eab61305fdc20fa5))
-* removing stats from running and failing ([#96](https://github.com/cdcgov/ocio-wsl/issues/96)) ([c8f689a](https://github.com/cdcgov/ocio-wsl/commit/c8f689a098905b0c432ee62bd313fed9ab2e7c5f))
+- updating dependencies, ordering dependencies for mise ([#76](https://github.com/cdcgov/ocio-wsl/issues/76)) ([08d4719](https://github.com/cdcgov/ocio-wsl/commit/08d47198ad87634ba6848141896b8b70f5fe6ef5))
 
-# [2.5.0](https://github.com/cdcent/ocio-wsl/compare/2.4.0...2.5.0) (2025-07-07)
-
+# [2.2.0](https://github.com/cdcgov/ocio-wsl/compare/2.1.0...2.2.0) (2025-03-11)
 
 ### Features
 
-* upgrading os packages and mise tools ([#83](https://github.com/cdcent/ocio-wsl/issues/83)) ([45a4033](https://github.com/cdcent/ocio-wsl/commit/45a40339c812b730c482f41e7e9acece542a5cb1))
+- use mise instead of asdf ([#72](https://github.com/cdcgov/ocio-wsl/issues/72)) ([0324327](https://github.com/cdcgov/ocio-wsl/commit/03243273da76d86dd53ba22d7ad685670d7ecdf2))
 
-# [2.4.0](https://github.com/cdcent/ocio-wsl/compare/2.3.0...2.4.0) (2025-04-09)
-
-
-### Features
-
-* Edso 2238 configure dns ([#81](https://github.com/cdcent/ocio-wsl/issues/81)) ([615b77d](https://github.com/cdcent/ocio-wsl/commit/615b77d89f76c620e6a982e725e84025c1f40042))
-
-# [2.3.0](https://github.com/cdcent/ocio-wsl/compare/2.2.1...2.3.0) (2025-04-03)
-
-
-### Features
-
-* EDSO-1089 add default user on startup ([#80](https://github.com/cdcent/ocio-wsl/issues/80)) ([063fb69](https://github.com/cdcent/ocio-wsl/commit/063fb697d2dee8d4fff3d5a62ff4ce44c0ff7067))
-
-## [2.2.1](https://github.com/cdcent/ocio-wsl/compare/2.2.0...2.2.1) (2025-04-01)
-
+# [2.1.0](https://github.com/cdcgov/ocio-wsl/compare/2.0.2...2.1.0) (2024-12-19)
 
 ### Bug Fixes
 
-* updating dependencies, ordering dependencies for mise ([#76](https://github.com/cdcent/ocio-wsl/issues/76)) ([08d4719](https://github.com/cdcent/ocio-wsl/commit/08d47198ad87634ba6848141896b8b70f5fe6ef5))
-
-# [2.2.0](https://github.com/cdcent/ocio-wsl/compare/2.1.0...2.2.0) (2025-03-11)
-
-
-### Features
-
-* use mise instead of asdf ([#72](https://github.com/cdcent/ocio-wsl/issues/72)) ([0324327](https://github.com/cdcent/ocio-wsl/commit/03243273da76d86dd53ba22d7ad685670d7ecdf2))
-
-# [2.1.0](https://github.com/cdcent/ocio-wsl/compare/2.0.2...2.1.0) (2024-12-19)
-
-
-### Bug Fixes
-
-* add sudo to default plugin, so that new users can have superpowers ([fa1c655](https://github.com/cdcent/ocio-wsl/commit/fa1c65512c0907c011dfca57a4e06b0008fba2c3))
-* adding default path and testing ([6a9ddb6](https://github.com/cdcent/ocio-wsl/commit/6a9ddb644cdd0845a39a88aac6dfdfd74dfee129))
-* creating the asdf directory to ensure it is there ([8f539c5](https://github.com/cdcent/ocio-wsl/commit/8f539c50b5bc4835e7d3a59d5cbc42c7bd7c68c4))
-* ensuring we end the quote properly ([4f9373f](https://github.com/cdcent/ocio-wsl/commit/4f9373faa1d14c56990dc31520ea251a490009d5))
-* fixing asdf's brokeness ([3454dfd](https://github.com/cdcent/ocio-wsl/commit/3454dfd4f01239f49dad402aa84d677f364fa662))
-* removing sudo usage and properly adding a new user to login ([b954731](https://github.com/cdcent/ocio-wsl/commit/b9547313193c02d0300d0160afd4bff5fd07aa6e))
-* setting up default bash scripts for new user in Linux ([c59fa1e](https://github.com/cdcent/ocio-wsl/commit/c59fa1e1ec6e59463f4d39f867e31c1e30d20e15))
-* simple cleanup ([666fc5e](https://github.com/cdcent/ocio-wsl/commit/666fc5e12c30fd0f14a1bb5736d09b8e9dd7908e))
-
+- add sudo to default plugin, so that new users can have superpowers ([fa1c655](https://github.com/cdcgov/ocio-wsl/commit/fa1c65512c0907c011dfca57a4e06b0008fba2c3))
+- adding default path and testing ([6a9ddb6](https://github.com/cdcgov/ocio-wsl/commit/6a9ddb644cdd0845a39a88aac6dfdfd74dfee129))
+- creating the asdf directory to ensure it is there ([8f539c5](https://github.com/cdcgov/ocio-wsl/commit/8f539c50b5bc4835e7d3a59d5cbc42c7bd7c68c4))
+- ensuring we end the quote properly ([4f9373f](https://github.com/cdcgov/ocio-wsl/commit/4f9373faa1d14c56990dc31520ea251a490009d5))
+- fixing asdf's brokeness ([3454dfd](https://github.com/cdcgov/ocio-wsl/commit/3454dfd4f01239f49dad402aa84d677f364fa662))
+- removing sudo usage and properly adding a new user to login ([b954731](https://github.com/cdcgov/ocio-wsl/commit/b9547313193c02d0300d0160afd4bff5fd07aa6e))
+- setting up default bash scripts for new user in Linux ([c59fa1e](https://github.com/cdcgov/ocio-wsl/commit/c59fa1e1ec6e59463f4d39f867e31c1e30d20e15))
+- simple cleanup ([666fc5e](https://github.com/cdcgov/ocio-wsl/commit/666fc5e12c30fd0f14a1bb5736d09b8e9dd7908e))
 
 ### Features
 
-* default bashrc files for new user in distro ([eb39667](https://github.com/cdcent/ocio-wsl/commit/eb39667378a3f3d2ea410a39821e0c39241a66c9))
-* new user creation and folder restructuring ([4f7c487](https://github.com/cdcent/ocio-wsl/commit/4f7c4876e3cc122db3e73da77270da846b8e81c9))
-* updating README with other WSL implementations ([2889d37](https://github.com/cdcent/ocio-wsl/commit/2889d37de54e605b64d76fdfe6bc0cf5da6c453e))
+- default bashrc files for new user in distro ([eb39667](https://github.com/cdcgov/ocio-wsl/commit/eb39667378a3f3d2ea410a39821e0c39241a66c9))
+- new user creation and folder restructuring ([4f7c487](https://github.com/cdcgov/ocio-wsl/commit/4f7c4876e3cc122db3e73da77270da846b8e81c9))
+- updating README with other WSL implementations ([2889d37](https://github.com/cdcgov/ocio-wsl/commit/2889d37de54e605b64d76fdfe6bc0cf5da6c453e))
 
-## [2.0.2](https://github.com/cdcent/ocio-wsl/compare/2.0.1...2.0.2) (2024-12-17)
-
-
-### Bug Fixes
-
-* updating dockerfile date ([f3fedd0](https://github.com/cdcent/ocio-wsl/commit/f3fedd08b0ef62ccc9a5fa07ffabd51e48ad35c3))
-* updating python version ([ced58da](https://github.com/cdcent/ocio-wsl/commit/ced58da40f5ab8347d2e4beb73181013f797d125))
-
-## [2.0.1](https://github.com/cdcent/ocio-wsl/compare/2.0.0...2.0.1) (2024-11-02)
-
+## [2.0.2](https://github.com/cdcgov/ocio-wsl/compare/2.0.1...2.0.2) (2024-12-17)
 
 ### Bug Fixes
 
-* **doc:** update the README ([a434089](https://github.com/cdcent/ocio-wsl/commit/a434089b3dbd3468e6170eb1662ef4e18bc48021))
+- updating dockerfile date ([f3fedd0](https://github.com/cdcgov/ocio-wsl/commit/f3fedd08b0ef62ccc9a5fa07ffabd51e48ad35c3))
+- updating python version ([ced58da](https://github.com/cdcgov/ocio-wsl/commit/ced58da40f5ab8347d2e4beb73181013f797d125))
 
-# [2.0.0](https://github.com/cdcent/ocio-wsl/compare/1.0.11...2.0.0) (2024-09-23)
+## [2.0.1](https://github.com/cdcgov/ocio-wsl/compare/2.0.0...2.0.1) (2024-11-02)
 
+### Bug Fixes
+
+- **doc:** update the README ([a434089](https://github.com/cdcgov/ocio-wsl/commit/a434089b3dbd3468e6170eb1662ef4e18bc48021))
+
+# [2.0.0](https://github.com/cdcgov/ocio-wsl/compare/1.0.11...2.0.0) (2024-09-23)
 
 ### Features
 
-* Dev/upgrade to ubuntu 24.04 (Waiting on 24.04.01 release) ([#47](https://github.com/cdcent/ocio-wsl/issues/47)) ([75096ea](https://github.com/cdcent/ocio-wsl/commit/75096ea141baaedd983269e3f5f2e8675b86d637))
-
+- Dev/upgrade to ubuntu 24.04 (Waiting on 24.04.01 release) ([#47](https://github.com/cdcgov/ocio-wsl/issues/47)) ([75096ea](https://github.com/cdcgov/ocio-wsl/commit/75096ea141baaedd983269e3f5f2e8675b86d637))
 
 ### BREAKING CHANGES
 
-* Upgrade to Ubuntu 24.04
+- Upgrade to Ubuntu 24.04
 
-* chore[update]: updating dependencies, add shellcheck
+- chore[update]: updating dependencies, add shellcheck
 
-* chore[update]: update semantic versioning
+- chore[update]: update semantic versioning
 
-## [1.0.11](https://github.com/cdcent/ocio-wsl/compare/1.0.10...1.0.11) (2024-07-22)
-
-
-### Bug Fixes
-
-* setting up certificate trust by default for basic languages ([#43](https://github.com/cdcent/ocio-wsl/issues/43)) ([cccb1b6](https://github.com/cdcent/ocio-wsl/commit/cccb1b6517b9ed1f4af4a4ccd17de9520302c614))
-
-## [1.0.10](https://github.com/cdcent/ocio-wsl/compare/1.0.9...1.0.10) (2024-07-22)
-
+## [1.0.11](https://github.com/cdcgov/ocio-wsl/compare/1.0.10...1.0.11) (2024-07-22)
 
 ### Bug Fixes
 
-* updating to the latest supported tools version ([#42](https://github.com/cdcent/ocio-wsl/issues/42)) ([1d36b8d](https://github.com/cdcent/ocio-wsl/commit/1d36b8d8eb9e56f0125e2cfe39279f3da9833477))
+- setting up certificate trust by default for basic languages ([#43](https://github.com/cdcgov/ocio-wsl/issues/43)) ([cccb1b6](https://github.com/cdcgov/ocio-wsl/commit/cccb1b6517b9ed1f4af4a4ccd17de9520302c614))
 
-## [1.0.9](https://github.com/cdcent/ocio-wsl/compare/1.0.8...1.0.9) (2024-06-20)
-
-
-### Bug Fixes
-
-* dependencies update for tools and package ([#38](https://github.com/cdcent/ocio-wsl/issues/38)) ([20e75b6](https://github.com/cdcent/ocio-wsl/commit/20e75b61993e64e5f3dd3341250b4072e5a8a420))
-* fixing deployment by not persisting checkout token ([#40](https://github.com/cdcent/ocio-wsl/issues/40)) ([a30bbe0](https://github.com/cdcent/ocio-wsl/commit/a30bbe09f7509920c70b0c5a74428958d8749340))
-
-## [1.0.8](https://github.com/cdcent/ocio-wsl/compare/1.0.7...1.0.8) (2024-04-11)
-
+## [1.0.10](https://github.com/cdcgov/ocio-wsl/compare/1.0.9...1.0.10) (2024-07-22)
 
 ### Bug Fixes
 
-* adding extra tools installation as a test ([#34](https://github.com/cdcent/ocio-wsl/issues/34)) ([33f219c](https://github.com/cdcent/ocio-wsl/commit/33f219c43e32fa1a289d674c8ed44da0f2421091))
-* **workflow:** avoid running dryrun if not in a Pull Request ([#35](https://github.com/cdcent/ocio-wsl/issues/35)) ([09f6ca0](https://github.com/cdcent/ocio-wsl/commit/09f6ca03fe35aed422f3e57fdd006ba62f503fae))
-* **workflow:** reordering and providing greater permissions ([#37](https://github.com/cdcent/ocio-wsl/issues/37)) ([756d953](https://github.com/cdcent/ocio-wsl/commit/756d953a986639ba7c831b702b0703543aa96b66))
+- updating to the latest supported tools version ([#42](https://github.com/cdcgov/ocio-wsl/issues/42)) ([1d36b8d](https://github.com/cdcgov/ocio-wsl/commit/1d36b8d8eb9e56f0125e2cfe39279f3da9833477))
 
-## [1.0.7](https://github.com/cdcent/ocio-wsl/compare/1.0.6...1.0.7) (2024-03-16)
-
+## [1.0.9](https://github.com/cdcgov/ocio-wsl/compare/1.0.8...1.0.9) (2024-06-20)
 
 ### Bug Fixes
 
-* adding ripgrep and r, fixing yarn ([#29](https://github.com/cdcent/ocio-wsl/issues/29)) ([46c14b0](https://github.com/cdcent/ocio-wsl/commit/46c14b0e90d47ae5bf2d9e8e0a1c0d84fbb4a6bb))
+- dependencies update for tools and package ([#38](https://github.com/cdcgov/ocio-wsl/issues/38)) ([20e75b6](https://github.com/cdcgov/ocio-wsl/commit/20e75b61993e64e5f3dd3341250b4072e5a8a420))
+- fixing deployment by not persisting checkout token ([#40](https://github.com/cdcgov/ocio-wsl/issues/40)) ([a30bbe0](https://github.com/cdcgov/ocio-wsl/commit/a30bbe09f7509920c70b0c5a74428958d8749340))
 
-## [1.0.6](https://github.com/cdcent/ocio-wsl/compare/1.0.5...1.0.6) (2024-03-11)
-
-
-### Bug Fixes
-
-* dependencies update based on latest provided dependencies ([#28](https://github.com/cdcent/ocio-wsl/issues/28)) ([57d155c](https://github.com/cdcent/ocio-wsl/commit/57d155c454813645edf5eab07c95d71b696e8eed))
-
-## [1.0.5](https://github.com/cdcent/ocio-wsl/compare/1.0.4...1.0.5) (2024-02-29)
-
+## [1.0.8](https://github.com/cdcgov/ocio-wsl/compare/1.0.7...1.0.8) (2024-04-11)
 
 ### Bug Fixes
 
-* adding deployment cron job ([#25](https://github.com/cdcent/ocio-wsl/issues/25)) ([54ea624](https://github.com/cdcent/ocio-wsl/commit/54ea624d5f306140df94b1e2d28c745fc978890e))
+- adding extra tools installation as a test ([#34](https://github.com/cdcgov/ocio-wsl/issues/34)) ([33f219c](https://github.com/cdcgov/ocio-wsl/commit/33f219c43e32fa1a289d674c8ed44da0f2421091))
+- **workflow:** avoid running dryrun if not in a Pull Request ([#35](https://github.com/cdcgov/ocio-wsl/issues/35)) ([09f6ca0](https://github.com/cdcgov/ocio-wsl/commit/09f6ca03fe35aed422f3e57fdd006ba62f503fae))
+- **workflow:** reordering and providing greater permissions ([#37](https://github.com/cdcgov/ocio-wsl/issues/37)) ([756d953](https://github.com/cdcgov/ocio-wsl/commit/756d953a986639ba7c831b702b0703543aa96b66))
 
-## [1.0.4](https://github.com/cdcent/ocio-wsl/compare/1.0.3...1.0.4) (2023-12-03)
-
-
-### Bug Fixes
-
-* bump version and add troubleshoot link ([#22](https://github.com/cdcent/ocio-wsl/issues/22)) ([29f79ba](https://github.com/cdcent/ocio-wsl/commit/29f79ba31c56f8d749f0a241922be1893b70c8fd))
-* magenta color for terminal directory, fix time change script, update README ([#23](https://github.com/cdcent/ocio-wsl/issues/23)) ([f8fa80d](https://github.com/cdcent/ocio-wsl/commit/f8fa80d84245b44c8857b9cf3869c7da29916a86))
-
-## [1.0.3](https://github.com/cdcent/ocio-wsl/compare/1.0.2...1.0.3) (2023-11-22)
-
+## [1.0.7](https://github.com/cdcgov/ocio-wsl/compare/1.0.6...1.0.7) (2024-03-16)
 
 ### Bug Fixes
 
-* set python to global usage and clean up documentation ([#18](https://github.com/cdcent/ocio-wsl/issues/18)) ([523381c](https://github.com/cdcent/ocio-wsl/commit/523381c288d23805900a44e209a2f341d2d0e286))
+- adding ripgrep and r, fixing yarn ([#29](https://github.com/cdcgov/ocio-wsl/issues/29)) ([46c14b0](https://github.com/cdcgov/ocio-wsl/commit/46c14b0e90d47ae5bf2d9e8e0a1c0d84fbb4a6bb))
 
-## [1.0.2](https://github.com/cdcent/ocio-wsl/compare/1.0.1...1.0.2) (2023-11-22)
-
-
-### Bug Fixes
-
-* generating checksums for ubuntu image ([#17](https://github.com/cdcent/ocio-wsl/issues/17)) ([4780219](https://github.com/cdcent/ocio-wsl/commit/47802190f735789486fd5a1421ed0e9e7c891ac2))
-
-## [1.0.1](https://github.com/cdcent/ocio-wsl/compare/1.0.0...1.0.1) (2023-11-20)
-
+## [1.0.6](https://github.com/cdcgov/ocio-wsl/compare/1.0.5...1.0.6) (2024-03-11)
 
 ### Bug Fixes
 
-* upgrading dev tools baseline, include python 3.11 support ([#16](https://github.com/cdcent/ocio-wsl/issues/16)) ([c50b27c](https://github.com/cdcent/ocio-wsl/commit/c50b27c8b9b129553a3a9eb397487832259203a4))
+- dependencies update based on latest provided dependencies ([#28](https://github.com/cdcgov/ocio-wsl/issues/28)) ([57d155c](https://github.com/cdcgov/ocio-wsl/commit/57d155c454813645edf5eab07c95d71b696e8eed))
+
+## [1.0.5](https://github.com/cdcgov/ocio-wsl/compare/1.0.4...1.0.5) (2024-02-29)
+
+### Bug Fixes
+
+- adding deployment cron job ([#25](https://github.com/cdcgov/ocio-wsl/issues/25)) ([54ea624](https://github.com/cdcgov/ocio-wsl/commit/54ea624d5f306140df94b1e2d28c745fc978890e))
+
+## [1.0.4](https://github.com/cdcgov/ocio-wsl/compare/1.0.3...1.0.4) (2023-12-03)
+
+### Bug Fixes
+
+- bump version and add troubleshoot link ([#22](https://github.com/cdcgov/ocio-wsl/issues/22)) ([29f79ba](https://github.com/cdcgov/ocio-wsl/commit/29f79ba31c56f8d749f0a241922be1893b70c8fd))
+- magenta color for terminal directory, fix time change script, update README ([#23](https://github.com/cdcgov/ocio-wsl/issues/23)) ([f8fa80d](https://github.com/cdcgov/ocio-wsl/commit/f8fa80d84245b44c8857b9cf3869c7da29916a86))
+
+## [1.0.3](https://github.com/cdcgov/ocio-wsl/compare/1.0.2...1.0.3) (2023-11-22)
+
+### Bug Fixes
+
+- set python to global usage and clean up documentation ([#18](https://github.com/cdcgov/ocio-wsl/issues/18)) ([523381c](https://github.com/cdcgov/ocio-wsl/commit/523381c288d23805900a44e209a2f341d2d0e286))
+
+## [1.0.2](https://github.com/cdcgov/ocio-wsl/compare/1.0.1...1.0.2) (2023-11-22)
+
+### Bug Fixes
+
+- generating checksums for ubuntu image ([#17](https://github.com/cdcgov/ocio-wsl/issues/17)) ([4780219](https://github.com/cdcgov/ocio-wsl/commit/47802190f735789486fd5a1421ed0e9e7c891ac2))
+
+## [1.0.1](https://github.com/cdcgov/ocio-wsl/compare/1.0.0...1.0.1) (2023-11-20)
+
+### Bug Fixes
+
+- upgrading dev tools baseline, include python 3.11 support ([#16](https://github.com/cdcgov/ocio-wsl/issues/16)) ([c50b27c](https://github.com/cdcgov/ocio-wsl/commit/c50b27c8b9b129553a3a9eb397487832259203a4))
 
 # 1.0.0 (2023-11-13)
 
-
 ### Bug Fixes
 
-* distro for semantic release ([#14](https://github.com/cdcent/ocio-wsl/issues/14)) ([aa75a99](https://github.com/cdcent/ocio-wsl/commit/aa75a99aec08f2b508fb4456e3f96801836f0a4d))
-
+- distro for semantic release ([#14](https://github.com/cdcgov/ocio-wsl/issues/14)) ([aa75a99](https://github.com/cdcgov/ocio-wsl/commit/aa75a99aec08f2b508fb4456e3f96801836f0a4d))
 
 ### Features
 
-* bumping feature version ([#13](https://github.com/cdcent/ocio-wsl/issues/13)) ([b3d870e](https://github.com/cdcent/ocio-wsl/commit/b3d870e267e0899bfd63804a8ce157a0c3e438ef))
+- bumping feature version ([#13](https://github.com/cdcgov/ocio-wsl/issues/13)) ([b3d870e](https://github.com/cdcgov/ocio-wsl/commit/b3d870e267e0899bfd63804a8ce157a0c3e438ef))

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Windows Subsystem Build
 
 [![semantic-release: conventional-commit](https://img.shields.io/badge/semantic--release-conventionalcommit-e10079?logo=semantic-release&style=for-the-badge)](https://github.com/semantic-release/semantic-release)
-[![last release](https://img.shields.io/github/release-date/cdcgov/ocio-wsl?style=for-the-badge)](https://img.shields.io/badge/cdcent/ocio-wsl/releases)
+[![last release](https://img.shields.io/github/release-date/cdcgov/ocio-wsl?style=for-the-badge)](https://img.shields.io/badge/cdcgov/ocio-wsl/releases)
 ![total downloads](https://img.shields.io/github/downloads/cdcgov/ocio-wsl/total?style=for-the-badge)
-[![latest tag](https://img.shields.io/github/v/tag/cdcent/ocio-wsl?style=for-the-badge)](https://github.com/cdcgov/ocio-wsl/releases)
+[![latest tag](https://img.shields.io/github/v/tag/cdcgov/ocio-wsl?style=for-the-badge)](https://github.com/cdcgov/ocio-wsl/releases)
 ![commit history](https://img.shields.io/github/commit-activity/y/cdcgov/ocio-wsl?label=commits&style=for-the-badge)
 
-This builds an Windows Subsystem Linux (WSL) tarball image for CDC as part of the developer experience. Builds are currently ![deploy badge](https://img.shields.io/github/actions/workflow/status/cdcgov/ocio-wsl/distro.yml).
+This builds an Windows Subsystem Linux (WSL) tarball image for CDC as part of the developer experience. Builds are currently ![deploy badge](https://img.shields.io/github/actions/workflow/status/cdcgov/ocio-wsl/deploy.yml).
 
 ## How to use this?
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,10 @@
             {
               "path": "images/checksums.txt",
               "label": "Checksums for integrity validation"
+            },
+            {
+              "path": "images/manifest.json",
+              "label": "WSL Distribution Manifest"
             }
           ]
         }


### PR DESCRIPTION
## Updates

- fix: splitting out distro.yml to check-pr.yml instead so that it doesn't have multiple responsibilities
- fix: have deploy.yml be the sole source of deployment, fix security issues
- fix: remove old org name `cdcent` as we've transferred this repository over to `cdcgov`.
- fix: badges in README still linking to wrong links.

## Testing Steps

-

## Notes

-
