### PR TITLE
fix: git completion for ubuntu + fedora image

### DIFF
--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -12,6 +12,7 @@ ENV LC_ALL=C.UTF-8
 ##############################################################################
 RUN dnf upgrade -y && dnf install -y \
   autossh \
+  bash-completion \
   ca-certificates \
   bind-utils \
   procps-ng \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -11,6 +11,7 @@ ENV LC_ALL=C.UTF-8
 ##############################################################################
 RUN apt-get update -q && apt-get upgrade -y && apt-get install -y \
   autossh \
+  bash-completion \
   ca-certificates \
   dnsutils \
   watch \

--- a/config/.bashrc
+++ b/config/.bashrc
@@ -91,12 +91,19 @@ if [ -f ~/.bash_aliases ]; then
     . ~/.bash_aliases
 fi
 
-# enable programmable completion features (you don't need to enable
-# this, if it's already enabled in /etc/bash.bashrc and /etc/profile
-# sources /etc/bash.bashrc).
-#if [ -f /etc/bash_completion ] && ! shopt -oq posix; then
-#    . /etc/bash_completion
-#fi
+# enable programmable completion features
+# /usr/share/bash-completion/bash_completion works on both Fedora and Ubuntu;
+# /etc/bash_completion is a Debian/Ubuntu-only shim that sources the same file.
+if ! shopt -oq posix; then
+    if [ -f /usr/share/bash-completion/bash_completion ]; then
+        . /usr/share/bash-completion/bash_completion
+    elif [ -f /etc/bash_completion ]; then
+        . /etc/bash_completion
+    fi
+fi
+
+# git completion (sourced explicitly in case the framework skips lazy-loading)
+[ -f /usr/share/bash-completion/completions/git ] && . /usr/share/bash-completion/completions/git
 parse_git_branch() {
   git branch 2> /dev/null | sed -e "/^[^*]/d" -e "s/* \(.*\)/(\1)/"
 }


### PR DESCRIPTION
## Updates

- fix: support bash and git completion #113. 

## Testing Steps

- test: build a podman image, and ran test.sh. once that finishes, run `podman exec -it fedora-43-cdc-test bash` and then run `ls --<tab>` to see it work.

## Notes

-
