### PR TITLE
fix: rely on mise to install python

### DIFF
--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -47,7 +47,6 @@ RUN dnf upgrade -y && dnf install -y \
   openssl-devel \
   libffi-devel \
   xz-devel \
-  python3 \
   zlib-devel \
   \
   # For R installation

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -44,7 +44,6 @@ RUN apt-get update -q && apt-get upgrade -y && apt-get install -y \
   libssl-dev \
   libffi-dev \
   liblzma-dev \
-  python3.13-venv \
   zlib1g-dev \
 
   # For R installation: https://github.com/asdf-community/asdf-r


### PR DESCRIPTION
## Updates

- fix: rely on mise to install python, instead of the package manager's version.

## Testing Steps

- test: built this locally to make sure it works.

## Notes

-
