### PR TITLE
fix: permission issue with resolv.conf where it's far too restrictive

### DIFF
--- a/scripts/run-once.sh
+++ b/scripts/run-once.sh
@@ -55,6 +55,7 @@ else
   while read -r ip; do
     echo "nameserver $ip" >> $DNSFILE
   done <<< "$DNSLIST"
+  chmod 644 $DNSFILE
   echo "DNS configuration written to $DNSFILE:"
   cat $DNSFILE
 fi


### PR DESCRIPTION
## Updates

- fix: tee writes a file that is far too restrictive, even for nslookup to view.

## Testing Steps

- test: debug with `strace nslookup google.com 2>&1 | grep -i resolv` to find a permission issue on the resolv.conf file.

## Notes

-
