### PR TITLE
fix: why is ping not installed by default

### DIFF
--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -32,6 +32,7 @@ RUN dnf upgrade -y && dnf install -y \
   vim \
   wget \
   whois \
+  iputils \
   tcpdump \
   \
   # For python installation
@@ -88,10 +89,6 @@ RUN rpm --import 'https://mise.jdx.dev/gpg-key.pub' && \
 COPY config/config.toml "${MISE_CONFIG_DIR}/config.toml"
 COPY config/config.toml "/etc/mise/config.toml"
 
-RUN echo 'export PATH="/opt/mise/bin:/opt/mise/shims:$PATH"' >> /etc/skel/.bashrc && \
-  echo 'export PATH="/opt/mise/bin:/opt/mise/shims:$PATH"' >> /root/.bashrc && \
-  echo 'eval "$(mise activate bash)"' >> /etc/skel/.bashrc && \
-  echo 'eval "$(mise activate bash)"' >> /root/.bashrc
 
 ENV REQUESTS_CA_BUNDLE='/etc/pki/tls/certs/ca-bundle.crt'
 ENV SSL_CERT_FILE='/etc/pki/tls/certs/ca-bundle.crt'

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -31,6 +31,7 @@ RUN apt-get update -q && apt-get upgrade -y && apt-get install -y \
   vim \
   wget \
   whois \
+  iputils-ping \
   tcpdump \
 
   # For python installation
@@ -100,11 +101,6 @@ RUN install -dm 755 /etc/apt/keyrings && \
 COPY config/config.toml "${MISE_CONFIG_DIR}/config.toml"
 COPY config/config.toml "/etc/mise/config.toml"
 
-# Ensure mise is initialized for all users
-RUN echo 'export PATH="/opt/mise/bin:/opt/mise/shims:$PATH"' >> /etc/skel/.bashrc && \
-  echo 'export PATH="/opt/mise/bin:/opt/mise/shims:$PATH"' >> /root/.bashrc && \
-  echo 'eval "$(mise activate bash)"' >> /etc/skel/.bashrc && \
-  echo 'eval "$(mise activate bash)"' >> /root/.bashrc
 
 # Ensure Python trusts the CDC root certificates, so that it can access internal 
 # websites signed by CDC's certificate and cross firewalls using man-in-the-middle 

--- a/config/.bashrc
+++ b/config/.bashrc
@@ -108,3 +108,6 @@ parse_git_branch() {
   git branch 2> /dev/null | sed -e "/^[^*]/d" -e "s/* \(.*\)/(\1)/"
 }
 PS1='${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;35m\]\w\[\033[01;31m\]$(parse_git_branch)\[\033[00m\]\$ '
+
+export PATH="/opt/mise/bin:/opt/mise/shims:$PATH"
+eval "$(mise activate bash)"


### PR DESCRIPTION
## Updates

- fix: ping for some strange reason isn't installed by default, or maybe mise is overwriting the PATH so ping isn't showing up. Either case, fixing the ordering of when mise activates and installing ping.

## Testing Steps

-

## Notes

-
